### PR TITLE
⚡️ Extract critical css for flexboxgrid

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
   "homepage": "https://github.com/carloscuesta/carloscuesta.me#readme",
   "dependencies": {
     "date-fns": "^2.14.0",
-    "flexboxgrid": "^6.3.1",
     "gray-matter": "^4.0.2",
     "lazysizes": "^5.2.2",
     "lodash.groupby": "^4.6.0",

--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -4,7 +4,6 @@ import { DefaultSeo } from 'next-seo'
 import Router from 'next/router'
 import 'lazysizes'
 import 'lazysizes/plugins/attrchange/ls.attrchange'
-import 'flexboxgrid/dist/flexboxgrid.min.css'
 
 import 'src/utils/theme/theme.css'
 import Layout from 'src/components/shared/Layout'

--- a/src/utils/theme/README.md
+++ b/src/utils/theme/README.md
@@ -8,3 +8,5 @@ There are two themes on the website:
 - Dark
 
 The default theme will be selected using the [`prefers-color-scheme`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme) property.
+
+The theme also includes the extracted critical-css of `flexboxgrid`.

--- a/src/utils/theme/theme.css
+++ b/src/utils/theme/theme.css
@@ -179,3 +179,59 @@ hr {
   background: rgba(255, 82, 82, 1);
   color: #fff;
 }
+
+/* Flexboxgrid.css critical */
+
+.row {
+  box-sizing: border-box;
+  display: flex;
+  flex: 0 1 auto;
+  flex-direction: row;
+  flex-wrap: wrap;
+  margin-right: -.5rem;
+  margin-left: -.5rem;
+}
+
+.col-xs-12 {
+  box-sizing: border-box;
+  flex: 0 0 auto;
+  padding-right: .5rem;
+  padding-left: .5rem;
+}
+
+.col-xs-12 {
+  flex-basis: 100%;
+  max-width: 100%;
+}
+
+.middle-xs {
+  align-items: center;
+}
+
+@media only screen and (min-width: 48em){
+  .col-sm-6 {
+    box-sizing: border-box;
+    flex: 0 0 auto;
+    padding-right: .5rem;
+    padding-left: .5rem;
+  }
+
+  .col-sm-6 {
+    flex-basis: 50%;
+    max-width: 50%;
+  }
+}
+
+@media only screen and (min-width: 64em){
+  .col-md-4 {
+    box-sizing: border-box;
+    flex: 0 0 auto;
+    padding-right: .5rem;
+    padding-left: .5rem;
+  }
+
+  .col-md-4 {
+    flex-basis: 33.33333333%;
+    max-width: 33.33333333%;
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4652,11 +4652,6 @@ flatted@^2.0.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.1.tgz#69e57caa8f0eacbc281d2e2cb458d46fdb449e08"
   integrity sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==
 
-flexboxgrid@^6.3.1:
-  version "6.3.1"
-  resolved "https://registry.yarnpkg.com/flexboxgrid/-/flexboxgrid-6.3.1.tgz#e99898afc07b7047722bb81a958a5fba4d4e20fd"
-  integrity sha1-6ZiYr8B7cEdyK7galYpfuk1OIP0=
-
 flow-bin@^0.128.0:
   version "0.128.0"
   resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.128.0.tgz#fd1232a64dc46874d8d499f16a1934b964f4c2ae"


### PR DESCRIPTION
## Description

Extract the used `flexboxgrid` classes to remove the amount of unused code that we were not using from the library. It's not the best solution since it's handled manually, however I couldn't figure out how to do this automatically on a simple way, since the CSS it's extracted from a lib.

