### PR TITLE
Add disqus to blog posts

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "next-seo": "^4.7.3",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
+    "react-intersection-observer": "^8.26.2",
     "rehype-preset-minify": "^5.0.3",
     "rehype-stringify": "^8.0.0",
     "remark-autolink-headings": "^6.0.1",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "dependencies": {
     "@mapbox/rehype-prism": "^0.5.0",
     "date-fns": "^2.15.0",
+    "disqus-react": "^1.0.9",
     "gray-matter": "^4.0.2",
     "lazysizes": "^5.2.2",
     "lodash.groupby": "^4.6.0",

--- a/src/__tests__/blog/[slug]/__snapshots__/slug.spec.js.snap
+++ b/src/__tests__/blog/[slug]/__snapshots__/slug.spec.js.snap
@@ -79,6 +79,11 @@ exports[`blog/[slug] page should match blog/[slug] page 1`] = `
       />
       <NewsletterSubscribe />
       <hr />
+      <DisqusComments
+        canonicalUrl="https://carloscuesta.me/blog/javascript-monorepos-lerna-yarn-workspaces"
+        postDisqusIdentifier="5bc9ff9949ac5006c0a84f00"
+        postTitle="JavaScript monorepos with Lerna and Yarn Workspaces"
+      />
     </Wrapper>
   </main>
 </article>

--- a/src/__tests__/blog/[slug]/slug.spec.js
+++ b/src/__tests__/blog/[slug]/slug.spec.js
@@ -18,6 +18,7 @@ jest.mock('src/components/pages/blog/[slug]/Header', () => 'Header')
 jest.mock('src/components/pages/blog/[slug]/FeaturedImage', () => 'FeaturedImage')
 jest.mock('src/components/pages/blog/[slug]/NewsletterSubscribe', () => 'NewsletterSubscribe')
 jest.mock('src/components/pages/blog/[slug]/ShareLinks', () => 'ShareLinks')
+jest.mock('src/components/pages/blog/[slug]/DisqusComments', () => 'DisqusComments')
 
 describe('blog/[slug]', () => {
   describe('page', () => {

--- a/src/components/pages/blog/[slug]/DisqusComments/__tests__/__snapshots__/disqusComments.spec.js.snap
+++ b/src/components/pages/blog/[slug]/DisqusComments/__tests__/__snapshots__/disqusComments.spec.js.snap
@@ -1,0 +1,20 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DisqusComments when the component is in viewport should render the Disqus component 1`] = `
+<div>
+  <div
+    config={
+      Object {
+        "identifier": "post-disqus-identifier",
+        "language": "en",
+        "title": "Post Title",
+        "url": "https://carloscuesta.me/canonical-url",
+      }
+    }
+    id="disqus_thread"
+    shortname="carloscuesta"
+  />
+</div>
+`;
+
+exports[`DisqusComments when the component is not in viewport should not render the Disqus component 1`] = `<div />`;

--- a/src/components/pages/blog/[slug]/DisqusComments/__tests__/disqusComments.spec.js
+++ b/src/components/pages/blog/[slug]/DisqusComments/__tests__/disqusComments.spec.js
@@ -1,0 +1,41 @@
+import React from 'react'
+import renderer from 'react-test-renderer'
+import { useInView } from 'react-intersection-observer'
+
+import DisqusComments from '../index'
+import * as stubs from './stubs'
+
+jest.mock('react-intersection-observer', () => ({
+  useInView: jest.fn().mockReturnValue([jest.fn(), false])
+}))
+
+describe('DisqusComments', () => {
+  it('should call useInView with the following options', () => {
+    renderer.create(<DisqusComments {...stubs.props} />)
+
+    expect(useInView).toHaveBeenCalledWith({
+      rootMargin: '440px',
+      triggerOnce: true
+    })
+  })
+
+  describe('when the component is not in viewport', () => {
+    it('should not render the Disqus component', () => {
+      const wrapper = renderer.create(<DisqusComments {...stubs.props} />)
+
+      expect(wrapper).toMatchSnapshot()
+    })
+  })
+
+  describe('when the component is in viewport', () => {
+    beforeAll(() => {
+      useInView.mockReturnValue([jest.fn(), true])
+    })
+
+    it('should render the Disqus component', () => {
+      const wrapper = renderer.create(<DisqusComments {...stubs.props} />)
+
+      expect(wrapper).toMatchSnapshot()
+    })
+  })
+})

--- a/src/components/pages/blog/[slug]/DisqusComments/__tests__/stubs.js
+++ b/src/components/pages/blog/[slug]/DisqusComments/__tests__/stubs.js
@@ -1,0 +1,5 @@
+export const props = {
+  canonicalUrl: 'https://carloscuesta.me/canonical-url',
+  postDisqusIdentifier: 'post-disqus-identifier',
+  postTitle: 'Post Title'
+}

--- a/src/components/pages/blog/[slug]/DisqusComments/index.js
+++ b/src/components/pages/blog/[slug]/DisqusComments/index.js
@@ -1,0 +1,36 @@
+// @flow
+import React from 'react'
+import { DiscussionEmbed } from 'disqus-react'
+import { useInView } from 'react-intersection-observer'
+
+type Props = {
+  canonicalUrl: string,
+  postDisqusIdentifier: string,
+  postTitle: string
+}
+
+const DisqusComments = (props: Props) => {
+  const [inViewRef, isInView] = useInView({
+    rootMargin: '440px',
+    triggerOnce: true
+  })
+
+  return (
+    <div ref={inViewRef}>
+      {
+        isInView &&
+          <DiscussionEmbed
+            shortname='carloscuesta'
+            config={{
+              identifier: props.postDisqusIdentifier,
+              language: 'en',
+              title: props.postTitle,
+              url: props.canonicalUrl
+            }}
+          />
+      }
+    </div>
+  )
+}
+
+export default DisqusComments

--- a/src/pages/blog/[slug]/index.js
+++ b/src/pages/blog/[slug]/index.js
@@ -10,6 +10,7 @@ import Header from 'src/components/pages/blog/[slug]/Header'
 import FeaturedImage from 'src/components/pages/blog/[slug]/FeaturedImage'
 import NewsletterSubscribe from 'src/components/pages/blog/[slug]/NewsletterSubscribe'
 import ShareLinks from 'src/components/pages/blog/[slug]/ShareLinks'
+import DisqusComments from 'src/components/pages/blog/[slug]/DisqusComments'
 
 type Props = {
   post: Post
@@ -85,6 +86,12 @@ const Article = (props: Props) => {
           <NewsletterSubscribe />
 
           <hr />
+
+          <DisqusComments
+            canonicalUrl={canonicalUrl}
+            postDisqusIdentifier={props.post.disqusIdentifier}
+            postTitle={props.post.title}
+          />
         </Wrapper>
       </main>
     </article>

--- a/yarn.lock
+++ b/yarn.lock
@@ -3581,6 +3581,11 @@ diffie-hellman@^5.0.0:
     miller-rabin "^4.0.0"
     randombytes "^2.0.0"
 
+disqus-react@^1.0.9:
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/disqus-react/-/disqus-react-1.0.9.tgz#ae66a3582e80dc22a493d53be5910143af9b7d5f"
+  integrity sha512-UoWAt0dJGsxQ/4SBYkTnNLqNzpDfAk9a/xTirkCKU5qFy9YbVN6JdZ4lUy9Mf7mz1B7eHkLtRXqVvY1KhpM4Hg==
+
 doctrine@1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-1.5.0.tgz#379dce730f6166f76cefa4e6707a159b02c5a6fa"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8305,6 +8305,13 @@ react-dom@^16.13.1:
     prop-types "^15.6.2"
     scheduler "^0.19.1"
 
+react-intersection-observer@^8.26.2:
+  version "8.26.2"
+  resolved "https://registry.yarnpkg.com/react-intersection-observer/-/react-intersection-observer-8.26.2.tgz#0562ff0c06b2b10e809190c2fa9b6ded656e6e16"
+  integrity sha512-GmSjLNK+oV7kS+BHfrJSaA4wF61ELA33gizKHmN+tk59UT6/aW8kkqvlrFGPwxGoaIzLKS2evfG5fgkw5MIIsg==
+  dependencies:
+    tiny-invariant "^1.1.0"
+
 react-is@16.13.1, react-is@^16.12.0, react-is@^16.8.1, react-is@^16.8.6:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
@@ -10093,6 +10100,11 @@ tiny-emitter@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/tiny-emitter/-/tiny-emitter-2.1.0.tgz#1d1a56edfc51c43e863cbb5382a72330e3555423"
   integrity sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==
+
+tiny-invariant@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.1.0.tgz#634c5f8efdc27714b7f386c35e6760991d230875"
+  integrity sha512-ytxQvrb1cPc9WBEI/HSeYYoGD0kWnGEOR8RY6KomWLBVhqz0RgTwVO9dLrGz7dC+nN9llyI7OKAgRq8Vq4ZBSw==
 
 tmp@^0.0.33:
   version "0.0.33"


### PR DESCRIPTION
## Description

Add Disqus using Intersection-Observer API to lazyload the component until is not visible on the Viewport.

Fixes #221 