### PR TITLE
🚸 Use scroll-snap to improve UX at writings section

### DIFF
--- a/src/components/pages/index/Writings/styles.module.css
+++ b/src/components/pages/index/Writings/styles.module.css
@@ -4,6 +4,7 @@
   */
   flex-wrap: nowrap!important;
   overflow-x: scroll;
+  scroll-snap-type: x mandatory;
 }
 
 .scrollablePosts:global(::-webkit-scrollbar) {

--- a/src/components/shared/BlogPost/styles.module.css
+++ b/src/components/shared/BlogPost/styles.module.css
@@ -8,6 +8,7 @@
   color: var(--text);
   margin-bottom: 1em;
   overflow: hidden;
+  scroll-snap-align: start;
   text-decoration: none;
   transition: all 0.2s ease-out;
 }


### PR DESCRIPTION
## Description

Use [`scroll-snap`](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-snap-type) to improve the UX of scrolling through the Posts section. 

With this property, it acts like a slider, that has steps on it, instead of scrolling with the momentum along the container.

