### PR TITLE
🔧 Move flow check to precommit hook instead of lint-staged

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,13 +95,12 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "lint-staged"
+      "pre-commit": "yarn run test:flow && lint-staged"
     }
   },
   "lint-staged": {
     "*.js": [
-      "yarn run test:lint:fix",
-      "yarn run test:flow"
+      "yarn run test:lint:fix"
     ]
   },
   "jest": {


### PR DESCRIPTION
## Description

Sometimes the `flow check` step that is executed as a `pre-commit` `lint-staged` fails. This is due to https://github.com/flowtype/flow-bin/issues/109. 

Moving it as a precommit hook solves the issue. 