### PR TITLE
✨ Add NPM downloads count to OpenSource page as a Stat

### DIFF
--- a/src/__tests__/opensource/__snapshots__/opensource.spec.js.snap
+++ b/src/__tests__/opensource/__snapshots__/opensource.spec.js.snap
@@ -15,6 +15,7 @@ Array [
       />
       <Stats
         followers={100}
+        packageDownloads={10000}
         repositories={10}
         stars={10624}
       />

--- a/src/__tests__/opensource/opensource.spec.js
+++ b/src/__tests__/opensource/opensource.spec.js
@@ -2,11 +2,13 @@ import renderer from 'react-test-renderer'
 
 import OpenSource, { getStaticProps } from 'src/pages/opensource'
 import { fetchRepositories, fetchUserInformation } from 'src/utils/api/github'
+import { fetchPublishedPackages, fetchDownloadsCount } from 'src/utils/api/npm'
 import * as stubs from './stubs'
 
 jest.mock('next-seo', () => ({ NextSeo: 'NextSeo' }))
 jest.mock('src/utils/api/blog')
 jest.mock('src/utils/api/github')
+jest.mock('src/utils/api/npm')
 
 /*
   I'm mocking the components since those are unit tested.
@@ -31,6 +33,8 @@ describe('index', () => {
     beforeAll(() => {
       fetchRepositories.mockReturnValue(stubs.repositories)
       fetchUserInformation.mockReturnValue(stubs.userInformation)
+      fetchPublishedPackages.mockReturnValue(stubs.publishedPackages)
+      fetchDownloadsCount.mockReturnValue(stubs.packageDownloads)
     })
 
     it('should return repositories and userInformation as props and set revalidate', async () => {
@@ -38,11 +42,14 @@ describe('index', () => {
 
       expect(fetchRepositories).toHaveBeenCalledWith()
       expect(fetchUserInformation).toHaveBeenCalledWith()
+      expect(fetchPublishedPackages).toHaveBeenCalledWith()
+      expect(fetchDownloadsCount).toHaveBeenCalledWith(stubs.publishedPackages)
 
       expect(props).toEqual({
         props: {
           repositories: stubs.repositories,
-          userInformation: stubs.userInformation
+          userInformation: stubs.userInformation,
+          packageDownloads: stubs.packageDownloads
         },
         revalidate: 3600
       })

--- a/src/__tests__/opensource/stubs.js
+++ b/src/__tests__/opensource/stubs.js
@@ -48,7 +48,12 @@ export const userInformation = {
   repositories: 10
 }
 
+export const publishedPackages = ['gitmojis', 'gitmoji-cli', 'react-native-error-boundary']
+
+export const packageDownloads = 10000
+
 export const props = {
+  packageDownloads,
   repositories,
   userInformation
 }

--- a/src/components/pages/opensource/Stats/__tests__/__snapshots__/stats.spec.js.snap
+++ b/src/components/pages/opensource/Stats/__tests__/__snapshots__/stats.spec.js.snap
@@ -61,12 +61,30 @@ exports[`Stats should match Stats component 1`] = `
         <p
           className="label"
         >
-          Public Repositories
+          Repositories
         </p>
         <strong
           className="value"
         >
           10
+        </strong>
+      </article>
+    </div>
+    <div
+      className="col-xs-12 col-sm-6 col-md-4"
+    >
+      <article
+        className="card"
+      >
+        <p
+          className="label"
+        >
+          NPM Downloads (Last year)
+        </p>
+        <strong
+          className="value"
+        >
+          100,000
         </strong>
       </article>
     </div>

--- a/src/components/pages/opensource/Stats/__tests__/stubs.js
+++ b/src/components/pages/opensource/Stats/__tests__/stubs.js
@@ -1,5 +1,6 @@
 export const props = {
   followers: 100,
+  packageDownloads: 100000,
   repositories: 10,
   stars: 10000
 }

--- a/src/components/pages/opensource/Stats/index.js
+++ b/src/components/pages/opensource/Stats/index.js
@@ -6,6 +6,7 @@ import Stat from './Stat'
 
 type Props = {
   followers: number,
+  packageDownloads: number,
   repositories: number,
   stars: number
 }
@@ -17,7 +18,8 @@ const Stats = (props: Props): Element<'section'> => (
     <div className='row'>
       <Stat label='GitHub Stars' value={props.stars} />
       <Stat label='GitHub Followers' value={props.followers} />
-      <Stat label='Public Repositories' value={props.repositories} />
+      <Stat label='Repositories' value={props.repositories} />
+      <Stat label='NPM Downloads (Last year)' value={props.packageDownloads} />
     </div>
   </section>
 )

--- a/src/pages/opensource/index.js
+++ b/src/pages/opensource/index.js
@@ -3,6 +3,7 @@ import React, { type Node } from 'react'
 import { NextSeo } from 'next-seo'
 
 import { fetchRepositories, fetchUserInformation } from 'src/utils/api/github'
+import { fetchPublishedPackages, fetchDownloadsCount } from 'src/utils/api/npm'
 import { type Repository, type UserInformation } from 'src/utils/api/github/mutators'
 import PageTitle from 'src/components/shared/PageTitle'
 import Wrapper from 'src/components/shared/Wrapper'
@@ -10,8 +11,9 @@ import Repositories from 'src/components/pages/opensource/Repositories'
 import Stats from 'src/components/pages/opensource/Stats'
 
 type Props = {
+  packageDownloads: number,
   repositories: Array<Repository>,
-  userInformation: UserInformation
+  userInformation: UserInformation,
 }
 
 const Index = (props: Props): Node => (
@@ -26,6 +28,7 @@ const Index = (props: Props): Node => (
 
         <Stats
           followers={props.userInformation.followers}
+          packageDownloads={props.packageDownloads}
           repositories={props.userInformation.repositories}
           stars={props.repositories
             .map((repository) => repository.stars)
@@ -39,13 +42,15 @@ const Index = (props: Props): Node => (
 )
 
 export const getStaticProps = async (): Promise<{ props: Props }> => {
-  const [repositories, userInformation] = await Promise.all([
+  const [repositories, userInformation, publishedPackages] = await Promise.all([
     fetchRepositories(),
-    fetchUserInformation()
+    fetchUserInformation(),
+    fetchPublishedPackages()
   ])
 
   return {
     props: {
+      packageDownloads: await fetchDownloadsCount(publishedPackages),
       repositories,
       userInformation
     },

--- a/src/utils/api/npm/__tests__/__snapshots__/npm.spec.js.snap
+++ b/src/utils/api/npm/__tests__/__snapshots__/npm.spec.js.snap
@@ -1,0 +1,28 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`NPM API Client apiCalls should match fetchDownloadsCount call 1`] = `
+Object {
+  "mutator": [Function],
+  "url": "https://api.npmjs.org/downloads/point/last-year/,,,,,",
+}
+`;
+
+exports[`NPM API Client apiCalls should match fetchPublishedPackages call 1`] = `
+Object {
+  "mutator": [Function],
+  "url": "https://registry.npmjs.org/-/v1/search?text=author:carloscuesta",
+}
+`;
+
+exports[`NPM API Client mutators transformDownloadsCount should aggregate all the downloads from packages 1`] = `151010`;
+
+exports[`NPM API Client mutators transformPublishedPackages should match the packages names 1`] = `
+Array [
+  "react-native-error-boundary",
+  "gitmoji-cli",
+  "gitmojis",
+  "react-native-layout-debug",
+  "hyper-materialshell",
+  "generator-starterkit",
+]
+`;

--- a/src/utils/api/npm/__tests__/fixtures/downloads.json
+++ b/src/utils/api/npm/__tests__/fixtures/downloads.json
@@ -1,0 +1,26 @@
+{
+  "gitmojis": {
+    "downloads": 696,
+    "package": "gitmojis",
+    "start": "2019-12-29",
+    "end": "2020-12-27"
+  },
+  "gitmoji-cli": {
+    "downloads": 67939,
+    "package": "gitmoji-cli",
+    "start": "2019-12-29",
+    "end": "2020-12-27"
+  },
+  "react-native-error-boundary": {
+    "downloads": 82211,
+    "package": "react-native-error-boundary",
+    "start": "2019-12-29",
+    "end": "2020-12-27"
+  },
+  "react-native-layout-debug": {
+    "downloads": 164,
+    "package": "react-native-layout-debug",
+    "start": "2019-12-29",
+    "end": "2020-12-27"
+  }
+}

--- a/src/utils/api/npm/__tests__/fixtures/publishedPackages.json
+++ b/src/utils/api/npm/__tests__/fixtures/publishedPackages.json
@@ -1,0 +1,293 @@
+{
+  "objects": [{
+      "package": {
+        "name": "react-native-error-boundary",
+        "scope": "unscoped",
+        "version": "1.1.6",
+        "description": "A simple and reusable React-Native error boundary component",
+        "keywords": [
+          "react-native",
+          "error",
+          "error boundary",
+          "error handler",
+          "componentDidCatch"
+        ],
+        "date": "2020-12-28T23:25:43.938Z",
+        "links": {
+          "npm": "https://www.npmjs.com/package/react-native-error-boundary",
+          "homepage": "https://github.com/carloscuesta/react-native-error-boundary",
+          "repository": "https://github.com/carloscuesta/react-native-error-boundary",
+          "bugs": "https://github.com/carloscuesta/react-native-error-boundary/issues"
+        },
+        "author": {
+          "name": "carloscuesta",
+          "email": "hi@carloscuesta.me",
+          "url": "https://carloscuesta.me",
+          "username": "carloscuesta"
+        },
+        "publisher": {
+          "username": "carloscuesta",
+          "email": "hi@carloscuesta.me"
+        },
+        "maintainers": [{
+          "username": "carloscuesta",
+          "email": "hi@carloscuesta.me"
+        }]
+      },
+      "score": {
+        "final": 0.41841004240545115,
+        "detail": {
+          "quality": 0.9437261664442081,
+          "popularity": 0.05321578801577735,
+          "maintenance": 0.3333333333333333
+        }
+      },
+      "searchScore": 0.000029236478
+    },
+    {
+      "package": {
+        "name": "gitmoji-cli",
+        "scope": "unscoped",
+        "version": "3.2.18",
+        "description": "A gitmoji client for using emojis on commit messages.",
+        "keywords": [
+          "gitmoji",
+          "emoji",
+          "carloscuesta",
+          "commit"
+        ],
+        "date": "2020-12-28T23:22:55.406Z",
+        "links": {
+          "npm": "https://www.npmjs.com/package/gitmoji-cli",
+          "homepage": "https://github.com/carloscuesta/gitmoji-cli#readme",
+          "repository": "https://github.com/carloscuesta/gitmoji-cli",
+          "bugs": "https://github.com/carloscuesta/gitmoji-cli/issues"
+        },
+        "author": {
+          "name": "carloscuesta",
+          "email": "hi@carloscuesta.me",
+          "url": "https://carloscuesta.me",
+          "username": "carloscuesta"
+        },
+        "publisher": {
+          "username": "carloscuesta",
+          "email": "hi@carloscuesta.me"
+        },
+        "maintainers": [{
+          "username": "carloscuesta",
+          "email": "hi@carloscuesta.me"
+        }]
+      },
+      "score": {
+        "final": 0.35120916063026847,
+        "detail": {
+          "quality": 0.6388572024217436,
+          "popularity": 0.1225295235345106,
+          "maintenance": 0.3333333333333333
+        }
+      },
+      "searchScore": 0.00000436891
+    },
+    {
+      "package": {
+        "name": "gitmojis",
+        "scope": "unscoped",
+        "version": "3.1.2",
+        "description": "An emoji guide for your commit messages.",
+        "keywords": [
+          "gitmoji",
+          "emoji",
+          "carloscuesta",
+          "commit"
+        ],
+        "date": "2020-12-28T23:16:27.948Z",
+        "links": {
+          "npm": "https://www.npmjs.com/package/gitmojis",
+          "homepage": "https://gitmoji.dev",
+          "repository": "https://github.com/carloscuesta/gitmoji",
+          "bugs": "https://github.com/carloscuesta/gitmoji/issues"
+        },
+        "author": {
+          "name": "carloscuesta",
+          "email": "hi@carloscuesta.me",
+          "url": "https://carloscuesta.me",
+          "username": "carloscuesta"
+        },
+        "publisher": {
+          "username": "carloscuesta",
+          "email": "hi@carloscuesta.me"
+        },
+        "maintainers": [{
+            "username": "carloscuesta",
+            "email": "hi@carloscuesta.me"
+          },
+          {
+            "username": "vhoyer",
+            "email": "contact@vhoyer.dev"
+          },
+          {
+            "username": "johannchopin",
+            "email": "johannchopin@pm.me"
+          }
+        ]
+      },
+      "score": {
+        "final": 0.3105436326535888,
+        "detail": {
+          "quality": 0.6369604617498182,
+          "popularity": 0.007968078462790509,
+          "maintenance": 0.3333333333333333
+        }
+      },
+      "searchScore": 3.8520486e-7
+    },
+    {
+      "package": {
+        "name": "react-native-layout-debug",
+        "scope": "unscoped",
+        "version": "1.1.1",
+        "description": "React native layout debugger.",
+        "keywords": [
+          "react-native",
+          "layout",
+          "debug",
+          "debugger"
+        ],
+        "date": "2017-01-06T23:23:17.680Z",
+        "links": {
+          "npm": "https://www.npmjs.com/package/react-native-layout-debug"
+        },
+        "author": {
+          "name": "Carlos Cuesta",
+          "email": "crloscuesta@gmail.com",
+          "url": "https://carloscuesta.me",
+          "username": "carloscuesta"
+        },
+        "publisher": {
+          "username": "carloscuesta",
+          "email": "crloscuesta@gmail.com"
+        },
+        "maintainers": [{
+            "username": "carloscuesta",
+            "email": "crloscuesta@gmail.com"
+          },
+          {
+            "username": "jlopezxs",
+            "email": "jlopezxs@gmail.com"
+          }
+        ]
+      },
+      "score": {
+        "final": 0.28424005602155406,
+        "detail": {
+          "quality": 0.9437261664442081,
+          "popularity": 0.003206303109404577,
+          "maintenance": 0
+        }
+      },
+      "searchScore": 6.864126e-8
+    },
+    {
+      "package": {
+        "name": "hyper-materialshell",
+        "scope": "unscoped",
+        "version": "1.6.5",
+        "description": "A material design theme for Hyper based on materialshell.",
+        "keywords": [
+          "hyper",
+          "hyperterm",
+          "theme",
+          "materialshell",
+          "material design"
+        ],
+        "date": "2020-12-28T23:19:15.535Z",
+        "links": {
+          "npm": "https://www.npmjs.com/package/hyper-materialshell",
+          "homepage": "https://github.com/carloscuesta/hyper-materialshell#readme",
+          "repository": "https://github.com/carloscuesta/hyper-materialshell",
+          "bugs": "https://github.com/carloscuesta/hyper-materialshell/issues"
+        },
+        "author": {
+          "name": "carloscuesta",
+          "email": "hi@carloscuesta.me",
+          "url": "https://carloscuesta.me",
+          "username": "carloscuesta"
+        },
+        "publisher": {
+          "username": "carloscuesta",
+          "email": "hi@carloscuesta.me"
+        },
+        "maintainers": [{
+          "username": "carloscuesta",
+          "email": "hi@carloscuesta.me"
+        }]
+      },
+      "score": {
+        "final": 0.22733576222686597,
+        "detail": {
+          "quality": 0.6267855221675919,
+          "popularity": 0.07651600406014064,
+          "maintenance": 0.03577001187296914
+        }
+      },
+      "searchScore": 1.44558525e-8
+    },
+    {
+      "package": {
+        "name": "generator-starterkit",
+        "scope": "unscoped",
+        "version": "1.3.9",
+        "description": "Yeoman generator that scaffolds out a front end development starterkit.",
+        "keywords": [
+          "yeoman-generator",
+          "starterkit-generator",
+          "front end",
+          "carlos cuesta",
+          "carlos cuesta starterkit",
+          "starterkit",
+          "gulp",
+          "sass",
+          "less",
+          "babel",
+          "jade",
+          "html",
+          "critical",
+          "web",
+          "jshint"
+        ],
+        "date": "2017-04-29T13:23:39.323Z",
+        "links": {
+          "npm": "https://www.npmjs.com/package/generator-starterkit",
+          "homepage": "https://generatorstarterkit.carloscuesta.me",
+          "repository": "https://github.com/carloscuesta/generator-starterkit",
+          "bugs": "https://github.com/carloscuesta/generator-starterkit/issues"
+        },
+        "author": {
+          "name": "Carlos Cuesta",
+          "email": "crloscuesta@gmail.com",
+          "url": "https://github.com/carloscuesta",
+          "username": "carloscuesta"
+        },
+        "publisher": {
+          "username": "carloscuesta",
+          "email": "crloscuesta@gmail.com"
+        },
+        "maintainers": [{
+          "username": "carloscuesta",
+          "email": "crloscuesta@gmail.com"
+        }]
+      },
+      "score": {
+        "final": 0.17117095500875718,
+        "detail": {
+          "quality": 0.5591454844474534,
+          "popularity": 0.009792313355774806,
+          "maintenance": 0
+        }
+      },
+      "searchScore": 8.108335e-11
+    }
+  ],
+  "total": 6,
+  "time": "Mon Dec 28 2020 23:28:03 GMT+0000 (UTC)"
+}

--- a/src/utils/api/npm/__tests__/npm.spec.js
+++ b/src/utils/api/npm/__tests__/npm.spec.js
@@ -1,0 +1,42 @@
+import callApi from 'src/utils/api/callApi'
+import { fetchPublishedPackages, fetchDownloadsCount } from '../index'
+import { transformPublishedPackages, transformDownloadsCount } from '../mutators'
+
+import publishedPackagesFixture from './fixtures/publishedPackages'
+import packageDownloadsFixture from './fixtures/downloads'
+
+jest.mock('src/utils/api/callApi')
+
+describe('NPM API Client', () => {
+  describe('apiCalls', () => {
+    beforeEach(() => {
+      callApi.mockReset()
+    })
+
+    it('should match fetchPublishedPackages call', () => {
+      fetchPublishedPackages()
+
+      expect(callApi.mock.calls[0][0]).toMatchSnapshot()
+    })
+
+    it('should match fetchDownloadsCount call', () => {
+      fetchDownloadsCount(publishedPackagesFixture.objects.map((pkg) => pkg.name))
+
+      expect(callApi.mock.calls[0][0]).toMatchSnapshot()
+    })
+  })
+
+  describe('mutators', () => {
+    describe('transformPublishedPackages', () => {
+      it('should match the packages names', () => {
+        expect(transformPublishedPackages(publishedPackagesFixture)).toMatchSnapshot()
+      })
+    })
+
+    describe('transformDownloadsCount', () => {
+      it('should aggregate all the downloads from packages', () => {
+        expect(transformDownloadsCount(packageDownloadsFixture)).toMatchSnapshot()
+      })
+    })
+  })
+})

--- a/src/utils/api/npm/index.js
+++ b/src/utils/api/npm/index.js
@@ -1,0 +1,13 @@
+// @flow
+import callApi from 'src/utils/api/callApi'
+import { transformPublishedPackages, transformDownloadsCount } from './mutators'
+
+export const fetchPublishedPackages = (): Promise<Array<string>> => callApi({
+  mutator: transformPublishedPackages,
+  url: 'https://registry.npmjs.org/-/v1/search?text=author:carloscuesta'
+})
+
+export const fetchDownloadsCount = (packages: Array<string>): Promise<number> => callApi({
+  mutator: transformDownloadsCount,
+  url: `https://api.npmjs.org/downloads/point/last-year/${packages.join()}`
+})

--- a/src/utils/api/npm/mutators.js
+++ b/src/utils/api/npm/mutators.js
@@ -1,0 +1,12 @@
+// @flow
+export const transformPublishedPackages = (payload: { objects: Array<Object> }): Array<string> => {
+  return payload.objects.map((pkg) => pkg.package.name)
+}
+
+export const transformDownloadsCount = (payload: Object): number => {
+  const packages: Array<Object> = Object.values(payload)
+
+  return packages
+    .map((pkg) => pkg.downloads)
+    .reduce((memo, value) => memo + value, 0)
+}


### PR DESCRIPTION
## Description

Using the `npm` registry API and downloads count API. I'm rendering the downloads count of all my packages for the last year.