### PR TITLE
🐛 Add scroll-margin-top to post headers

### DIFF
--- a/src/utils/theme/theme.css
+++ b/src/utils/theme/theme.css
@@ -161,6 +161,7 @@ hr {
 .postDetail h6 {
   line-height: 1.15;
   position: relative;
+  scroll-margin-top: 4.5rem;
 }
 
 .postDetail .headingLink {


### PR DESCRIPTION
## Description

At the moment I made the `header` sticky, the post detail blog anchor links, now are hidden behind that header. We need to add `scroll-margin-top` to fix this.


