### PR TITLE
🔧 Enable Next.js ESModules support

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -4,5 +4,6 @@ module.exports = withPWA({
   pwa: {
     disable: process.env.NODE_ENV === 'development',
     dest: 'public'
-  }
+  },
+  experimental: { esmExternals: true }
 })


### PR DESCRIPTION
## Description

Enabling ESModule support is needed to update all the unified, remark, and rehype dependencies!