### PR TITLE
✨ Replace `lazySizes` with `plaiceholder` and update LQPI strategy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,5 +33,6 @@ jobs:
         LHCI_GITHUB_APP_TOKEN: ${{ secrets.LHCI_GITHUB_APP_TOKEN }}
         KV_REST_API_URL: ${{ secrets.KV_REST_API_URL }}
         KV_REST_API_TOKEN: ${{ secrets.KV_REST_API_TOKEN }}
+        NEXT_PUBLIC_API_MOCKING: true
     - name: Upload Coverage 📈
       run: yarn run test:coverage

--- a/next.config.js
+++ b/next.config.js
@@ -1,9 +1,11 @@
+const { withPlaiceholder } = require("@plaiceholder/next");
+
 const withPWA = require('next-pwa')({
   disable: process.env.NODE_ENV === 'development',
   dest: 'public'
 })
 
-module.exports = withPWA({
+module.exports = withPWA(withPlaiceholder({
   experimental: {
     appDir: true,
     // https://beta.nextjs.org/docs/api-reference/next-config#servercomponentsexternalpackages
@@ -26,4 +28,4 @@ module.exports = withPWA({
       permanent: true
     }
   ]
-})
+}))

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "date-fns": "^2.30.0",
     "disqus-react": "^1.1.5",
     "gray-matter": "^4.0.3",
-    "lazysizes": "^5.3.2",
     "lodash.debounce": "^4.0.8",
     "lodash.groupby": "^4.6.0",
     "lodash.truncate": "4.4.2",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "homepage": "https://github.com/carloscuesta/carloscuesta.me#readme",
   "dependencies": {
     "@headlessui/react": "1.7.14",
+    "@plaiceholder/next": "2.5.0",
     "@types/lodash.truncate": "4.4.7",
     "@vercel/analytics": "^1.0.1",
     "@vercel/kv": "0.1.2",
@@ -47,6 +48,7 @@
     "next-pwa": "^5.6.0",
     "next-seo": "^6.0.0",
     "next-themes": "0.2.1",
+    "plaiceholder": "2.5.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-intersection-observer": "^9.4.3",

--- a/src/app/blog/[slug]/components/FeaturedImage/__tests__/__snapshots__/featuredImage.spec.tsx.snap
+++ b/src/app/blog/[slug]/components/FeaturedImage/__tests__/__snapshots__/featuredImage.spec.tsx.snap
@@ -6,11 +6,24 @@ exports[`FeaturedImage should match FeaturedImage component 1`] = `
 >
   <img
     alt="post title"
-    className="lazyload lazy-blur my-8 rounded-lg"
-    data-src="https://res.cloudinary.com/carloscuesta/image/upload/v1454754838/kcuq34zbo1yieygmx0y6.png"
+    className="my-8 rounded-lg"
+    data-nimg="1"
+    decoding="async"
     height={376}
-    src="https://res.cloudinary.com/carloscuesta/image/upload/t_post-preview-lqpi/v1454754838/kcuq34zbo1yieygmx0y6.png"
-    title="post title"
+    loading="lazy"
+    onError={[Function]}
+    onLoad={[Function]}
+    src="/_next/image?url=https%3A%2F%2Fres.cloudinary.com%2Fcarloscuesta%2Fimage%2Fupload%2Fv1454754838%2Fkcuq34zbo1yieygmx0y6.png&w=1920&q=75"
+    srcSet="/_next/image?url=https%3A%2F%2Fres.cloudinary.com%2Fcarloscuesta%2Fimage%2Fupload%2Fv1454754838%2Fkcuq34zbo1yieygmx0y6.png&w=828&q=75 1x, /_next/image?url=https%3A%2F%2Fres.cloudinary.com%2Fcarloscuesta%2Fimage%2Fupload%2Fv1454754838%2Fkcuq34zbo1yieygmx0y6.png&w=1920&q=75 2x"
+    style={
+      {
+        "backgroundImage": "url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http%3A//www.w3.org/2000/svg' viewBox='0 0 752 376'%3E%3Cfilter id='b' color-interpolation-filters='sRGB'%3E%3CfeGaussianBlur stdDeviation='20'/%3E%3C/filter%3E%3Cimage preserveAspectRatio='none' filter='url(%23b)' x='0' y='0' height='100%25' width='100%25' href='https://res.cloudinary.com/carloscuesta/image/upload/t_post-preview-lqpi/v1454754838/kcuq34zbo1yieygmx0y6.png'/%3E%3C/svg%3E")",
+        "backgroundPosition": "50% 50%",
+        "backgroundRepeat": "no-repeat",
+        "backgroundSize": "cover",
+        "color": "transparent",
+      }
+    }
     width={752}
   />
 </header>

--- a/src/app/blog/[slug]/components/FeaturedImage/index.tsx
+++ b/src/app/blog/[slug]/components/FeaturedImage/index.tsx
@@ -1,4 +1,4 @@
-'use client'
+import Image from 'next/image'
 
 type Props = {
   image: string
@@ -8,14 +8,14 @@ type Props = {
 
 const FeaturedImage = (props: Props) => (
   <header className="relative">
-    <img
+    <Image
       alt={props.title}
-      className="lazyload lazy-blur my-8 rounded-lg"
-      data-src={props.image}
-      title={props.title}
-      src={props.lqpiImage}
-      width={752}
+      blurDataURL={props.lqpiImage}
+      className="my-8 rounded-lg"
       height={376}
+      placeholder="blur"
+      src={props.image}
+      width={752}
     />
   </header>
 )

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -10,6 +10,8 @@ import Post from './components/Post'
 
 export const revalidate = 60
 
+export const dynamic = 'force-static'
+
 const getData = async () => {
   const posts = await fetchPosts()
   const views = await fetchViews()

--- a/src/app/home/components/Writings/BlogPost/__tests__/__snapshots__/blogPost.spec.tsx.snap
+++ b/src/app/home/components/Writings/BlogPost/__tests__/__snapshots__/blogPost.spec.tsx.snap
@@ -15,9 +15,25 @@ exports[`BlogPost should match BlogPost component 1`] = `
     <article>
       <img
         alt=""
-        className="lazyload mb-3 w-full rounded-lg"
-        data-src="https://res.cloudinary.com/carloscuesta/image/upload/w_500/v1454754838/kcuq34zbo1yieygmx0y6.png"
-        src="https://res.cloudinary.com/carloscuesta/image/upload/t_lqpi-post-preview/v1454754838/kcuq34zbo1yieygmx0y6.png"
+        className="mb-3 w-full rounded-lg"
+        data-nimg="1"
+        decoding="async"
+        height={150}
+        loading="lazy"
+        onError={[Function]}
+        onLoad={[Function]}
+        src="/_next/image?url=https%3A%2F%2Fres.cloudinary.com%2Fcarloscuesta%2Fimage%2Fupload%2Fw_500%2Fv1454754838%2Fkcuq34zbo1yieygmx0y6.png&w=640&q=75"
+        srcSet="/_next/image?url=https%3A%2F%2Fres.cloudinary.com%2Fcarloscuesta%2Fimage%2Fupload%2Fw_500%2Fv1454754838%2Fkcuq34zbo1yieygmx0y6.png&w=384&q=75 1x, /_next/image?url=https%3A%2F%2Fres.cloudinary.com%2Fcarloscuesta%2Fimage%2Fupload%2Fw_500%2Fv1454754838%2Fkcuq34zbo1yieygmx0y6.png&w=640&q=75 2x"
+        style={
+          {
+            "backgroundImage": "url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http%3A//www.w3.org/2000/svg' viewBox='0 0 300 150'%3E%3Cfilter id='b' color-interpolation-filters='sRGB'%3E%3CfeGaussianBlur stdDeviation='20'/%3E%3C/filter%3E%3Cimage preserveAspectRatio='none' filter='url(%23b)' x='0' y='0' height='100%25' width='100%25' href='https://res.cloudinary.com/carloscuesta/image/upload/t_lqpi-post-preview/v1454754838/kcuq34zbo1yieygmx0y6.png'/%3E%3C/svg%3E")",
+            "backgroundPosition": "50% 50%",
+            "backgroundRepeat": "no-repeat",
+            "backgroundSize": "cover",
+            "color": "transparent",
+          }
+        }
+        width={300}
       />
       <div
         className="grid gap-2"

--- a/src/app/home/components/Writings/BlogPost/__tests__/__snapshots__/blogPost.spec.tsx.snap
+++ b/src/app/home/components/Writings/BlogPost/__tests__/__snapshots__/blogPost.spec.tsx.snap
@@ -18,8 +18,8 @@ exports[`BlogPost should match BlogPost component 1`] = `
         className="mb-3 w-full rounded-lg"
         data-nimg="1"
         decoding="async"
+        fetchpriority="high"
         height={150}
-        loading="lazy"
         onError={[Function]}
         onLoad={[Function]}
         src="/_next/image?url=https%3A%2F%2Fres.cloudinary.com%2Fcarloscuesta%2Fimage%2Fupload%2Fw_500%2Fv1454754838%2Fkcuq34zbo1yieygmx0y6.png&w=640&q=75"

--- a/src/app/home/components/Writings/BlogPost/__tests__/stubs.ts
+++ b/src/app/home/components/Writings/BlogPost/__tests__/stubs.ts
@@ -22,4 +22,5 @@ export const props = {
     slug: 'post-slug',
     title: 'Post Title',
   },
+  isFirstItem: true,
 }

--- a/src/app/home/components/Writings/BlogPost/index.tsx
+++ b/src/app/home/components/Writings/BlogPost/index.tsx
@@ -1,3 +1,4 @@
+import Image from 'next/image'
 import Link from 'next/link'
 
 import { type PostPreview } from 'src/utils/api/blog/mutators'
@@ -14,11 +15,14 @@ const BlogPost = (props: Props) => (
       className="h-full rounded-lg outline-none ring-offset-4 focus-visible:ring-2 sm:flex"
     >
       <article>
-        <img
+        <Image
           alt=""
-          className="lazyload mb-3 w-full rounded-lg"
-          data-src={props.post.images.preview.src}
-          src={props.post.images.preview.lqpi}
+          blurDataURL={props.post.images.preview.lqpi}
+          className="mb-3 w-full rounded-lg"
+          height={150}
+          placeholder="blur"
+          src={props.post.images.preview.src}
+          width={300}
         />
 
         <div className="grid gap-2">

--- a/src/app/home/components/Writings/BlogPost/index.tsx
+++ b/src/app/home/components/Writings/BlogPost/index.tsx
@@ -5,6 +5,7 @@ import { type PostPreview } from 'src/utils/api/blog/mutators'
 
 type Props = {
   post: PostPreview
+  isFirstItem: boolean
 }
 
 const BlogPost = (props: Props) => (
@@ -21,6 +22,7 @@ const BlogPost = (props: Props) => (
           className="mb-3 w-full rounded-lg"
           height={150}
           placeholder="blur"
+          priority={props.isFirstItem}
           src={props.post.images.preview.src}
           width={300}
         />

--- a/src/app/home/components/Writings/__tests__/__snapshots__/writings.spec.tsx.snap
+++ b/src/app/home/components/Writings/__tests__/__snapshots__/writings.spec.tsx.snap
@@ -59,9 +59,12 @@ exports[`Writings should match Writings component 1`] = `
           <article>
             <img
               alt=""
-              className="lazyload mb-3 w-full rounded-lg"
-              data-src="https://res.cloudinary.com/carloscuesta/image/upload/w_500/v1454754838/kcuq34zbo1yieygmx0y6.png"
-              src="https://res.cloudinary.com/carloscuesta/image/upload/t_lqpi-post-preview/v1454754838/kcuq34zbo1yieygmx0y6.png"
+              blurDataURL="https://res.cloudinary.com/carloscuesta/image/upload/t_lqpi-post-preview/v1454754838/kcuq34zbo1yieygmx0y6.png"
+              className="mb-3 w-full rounded-lg"
+              height={150}
+              placeholder="blur"
+              src="https://res.cloudinary.com/carloscuesta/image/upload/w_500/v1454754838/kcuq34zbo1yieygmx0y6.png"
+              width={300}
             />
             <div
               className="grid gap-2"
@@ -94,9 +97,12 @@ exports[`Writings should match Writings component 1`] = `
           <article>
             <img
               alt=""
-              className="lazyload mb-3 w-full rounded-lg"
-              data-src="https://res.cloudinary.com/carloscuesta/image/upload/w_500/v1454754838/kcuq34zbo1yieygmx0y6.png"
-              src="https://res.cloudinary.com/carloscuesta/image/upload/t_lqpi-post-preview/v1454754838/kcuq34zbo1yieygmx0y6.png"
+              blurDataURL="https://res.cloudinary.com/carloscuesta/image/upload/t_lqpi-post-preview/v1454754838/kcuq34zbo1yieygmx0y6.png"
+              className="mb-3 w-full rounded-lg"
+              height={150}
+              placeholder="blur"
+              src="https://res.cloudinary.com/carloscuesta/image/upload/w_500/v1454754838/kcuq34zbo1yieygmx0y6.png"
+              width={300}
             />
             <div
               className="grid gap-2"

--- a/src/app/home/components/Writings/__tests__/__snapshots__/writings.spec.tsx.snap
+++ b/src/app/home/components/Writings/__tests__/__snapshots__/writings.spec.tsx.snap
@@ -63,6 +63,7 @@ exports[`Writings should match Writings component 1`] = `
               className="mb-3 w-full rounded-lg"
               height={150}
               placeholder="blur"
+              priority={true}
               src="https://res.cloudinary.com/carloscuesta/image/upload/w_500/v1454754838/kcuq34zbo1yieygmx0y6.png"
               width={300}
             />
@@ -101,6 +102,7 @@ exports[`Writings should match Writings component 1`] = `
               className="mb-3 w-full rounded-lg"
               height={150}
               placeholder="blur"
+              priority={false}
               src="https://res.cloudinary.com/carloscuesta/image/upload/w_500/v1454754838/kcuq34zbo1yieygmx0y6.png"
               width={300}
             />

--- a/src/app/home/components/Writings/__tests__/writings.spec.tsx
+++ b/src/app/home/components/Writings/__tests__/writings.spec.tsx
@@ -3,6 +3,13 @@ import renderer from 'react-test-renderer'
 import Writings from '../index'
 import * as stubs from './stubs'
 
+jest.mock('next/image', () => ({
+  __esModule: true,
+  default: (props: object) => {
+    return <img {...props} />
+  },
+}))
+
 describe('Writings', () => {
   it('should match Writings component', () => {
     const wrapper = renderer.create(<Writings {...stubs.props} />)

--- a/src/app/home/components/Writings/index.tsx
+++ b/src/app/home/components/Writings/index.tsx
@@ -64,8 +64,8 @@ const Writings = (props: Props) => {
           onScroll={onScroll}
           ref={scrollablePostsRef}
         >
-          {props.posts.map((post) => (
-            <BlogPost key={post.slug} post={post} />
+          {props.posts.map((post, index) => (
+            <BlogPost isFirstItem={index === 0} key={post.slug} post={post} />
           ))}
         </div>
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -38,6 +38,10 @@ export const metadata = {
   },
 }
 
+if (process.env.NEXT_PUBLIC_API_MOCKING === 'enabled') {
+  require('src/mocks')
+}
+
 const font = localFont({
   src: [
     {

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -1,7 +1,5 @@
 'use client'
 
-import 'lazysizes'
-import 'lazysizes/plugins/attrchange/ls.attrchange'
 import { ThemeProvider } from 'next-themes'
 
 const Providers = ({ children }: { children: JSX.Element[] | JSX.Element }) => (

--- a/src/mocks/index.ts
+++ b/src/mocks/index.ts
@@ -3,10 +3,10 @@ const IS_SERVER = typeof window === 'undefined'
 async function setupMocks() {
   if (IS_SERVER) {
     const { server } = await import('./server')
-    server.listen()
+    server.listen({ onUnhandledRequest: 'bypass' })
   } else {
     const { worker } = await import('./browser')
-    worker.start()
+    worker.start({ quiet: true })
   }
 }
 

--- a/src/utils/api/blog/__tests__/__snapshots__/blog.spec.ts.snap
+++ b/src/utils/api/blog/__tests__/__snapshots__/blog.spec.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Ghost API Client fetchPost should return a post with the slug terminal-setup 1`] = `
+exports[`Blog API Client fetchPost should return a post with the slug terminal-setup 1`] = `
 {
   "dateModified": "2016-02-06 15:55",
   "datePublished": {
@@ -20,7 +20,7 @@ exports[`Ghost API Client fetchPost should return a post with the slug terminal-
       "src": "https://res.cloudinary.com/carloscuesta/image/upload/v1593531858/blog-featured-images/Terminal_Setup.png",
     },
     "preview": {
-      "lqpi": "https://res.cloudinary.com/carloscuesta/image/upload/t_post-preview-lqpi/v1593531858/blog-featured-images/Terminal_Setup.png",
+      "lqpi": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAQAAAACCAIAAADwyuo0AAAACXBIWXMAABcRAAAXEQHKJvM/AAAADklEQVR4nGMQRQIMyBwAGbIB+ZVuRQQAAAAASUVORK5CYII=",
       "src": "https://res.cloudinary.com/carloscuesta/image/upload/w_500/v1593531858/blog-featured-images/Terminal_Setup.png",
     },
   },
@@ -30,7 +30,7 @@ exports[`Ghost API Client fetchPost should return a post with the slug terminal-
 }
 `;
 
-exports[`Ghost API Client fetchPosts should return an array of posts sorted by datePublished 1`] = `
+exports[`Blog API Client fetchPosts should return an array of posts sorted by datePublished 1`] = `
 [
   {
     "datePublished": {
@@ -45,7 +45,7 @@ exports[`Ghost API Client fetchPosts should return an array of posts sorted by d
         "src": "https://res.cloudinary.com/carloscuesta/image/upload/v1682161443/blog-featured-images/react-miami.jpg",
       },
       "preview": {
-        "lqpi": "https://res.cloudinary.com/carloscuesta/image/upload/t_post-preview-lqpi/v1682161443/blog-featured-images/react-miami.jpg",
+        "lqpi": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAQAAAACCAIAAADwyuo0AAAACXBIWXMAABcSAAAXEgFnn9JSAAAADklEQVR4nGNgRAIMyBwAAVIAGQHQACAAAAAASUVORK5CYII=",
         "src": "https://res.cloudinary.com/carloscuesta/image/upload/w_500/v1682161443/blog-featured-images/react-miami.jpg",
       },
     },
@@ -65,7 +65,7 @@ exports[`Ghost API Client fetchPosts should return an array of posts sorted by d
         "src": "https://res.cloudinary.com/carloscuesta/image/upload/v1675022732/blog-featured-images/Effective_Refactoring_with_Codemods.png",
       },
       "preview": {
-        "lqpi": "https://res.cloudinary.com/carloscuesta/image/upload/t_post-preview-lqpi/v1675022732/blog-featured-images/Effective_Refactoring_with_Codemods.png",
+        "lqpi": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAQAAAACCAIAAADwyuo0AAAACXBIWXMAABcRAAAXEQHKJvM/AAAAD0lEQVR4nGNgSPiPQMgcAIa6CvnplqETAAAAAElFTkSuQmCC",
         "src": "https://res.cloudinary.com/carloscuesta/image/upload/w_500/v1675022732/blog-featured-images/Effective_Refactoring_with_Codemods.png",
       },
     },
@@ -85,7 +85,7 @@ exports[`Ghost API Client fetchPosts should return an array of posts sorted by d
         "src": "https://res.cloudinary.com/carloscuesta/image/upload/v1653167435/blog-featured-images/Code_generators.png",
       },
       "preview": {
-        "lqpi": "https://res.cloudinary.com/carloscuesta/image/upload/t_post-preview-lqpi/v1653167435/blog-featured-images/Code_generators.png",
+        "lqpi": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAQAAAACCAIAAADwyuo0AAAACXBIWXMAABcRAAAXEQHKJvM/AAAADklEQVR4nGMQRQIMyBwAGbIB+ZVuRQQAAAAASUVORK5CYII=",
         "src": "https://res.cloudinary.com/carloscuesta/image/upload/w_500/v1653167435/blog-featured-images/Code_generators.png",
       },
     },
@@ -95,7 +95,7 @@ exports[`Ghost API Client fetchPosts should return an array of posts sorted by d
 ]
 `;
 
-exports[`Ghost API Client getPostSlugs should match getPostSlugs 1`] = `
+exports[`Blog API Client getPostSlugs should match getPostSlugs 1`] = `
 [
   "2016-year-in-review",
   "chrome-devtools-customization",
@@ -131,7 +131,7 @@ exports[`Ghost API Client getPostSlugs should match getPostSlugs 1`] = `
 ]
 `;
 
-exports[`Ghost API Client mutators transformPost should match the mutated post 1`] = `
+exports[`Blog API Client mutators transformPost should match the mutated post 1`] = `
 {
   "dateModified": "2016-02-06 15:55",
   "datePublished": {
@@ -148,7 +148,7 @@ exports[`Ghost API Client mutators transformPost should match the mutated post 1
       "src": "https://res.cloudinary.com/carloscuesta/image/upload/v1454754838/kcuq34zbo1yieygmx0y6.png",
     },
     "preview": {
-      "lqpi": "https://res.cloudinary.com/carloscuesta/image/upload/t_post-preview-lqpi/v1454754838/kcuq34zbo1yieygmx0y6.png",
+      "lqpi": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAQAAAACCAIAAADwyuo0AAAACXBIWXMAABcRAAAXEQHKJvM/AAAADklEQVR4nGMQRQIMyBwAGbIB+ZVuRQQAAAAASUVORK5CYII=",
       "src": "https://res.cloudinary.com/carloscuesta/image/upload/w_500/v1454754838/kcuq34zbo1yieygmx0y6.png",
     },
   },

--- a/src/utils/api/blog/__tests__/blog.spec.ts
+++ b/src/utils/api/blog/__tests__/blog.spec.ts
@@ -7,7 +7,7 @@ import postFixture from './fixtures/post.json'
 /* Mock Date.now to avoid updating snapshots for formatDistanceToNow */
 Date.now = jest.fn(() => 1593025862540)
 
-describe('Ghost API Client', () => {
+describe('Blog API Client', () => {
   describe('getPostSlugs', () => {
     it('should match getPostSlugs', () => {
       expect(getPostSlugs()).toMatchSnapshot()
@@ -32,9 +32,9 @@ describe('Ghost API Client', () => {
 
   describe('mutators', () => {
     describe('transformPost', () => {
-      it('should match the mutated post', () => {
+      it('should match the mutated post', async () => {
         expect(
-          transformPost({
+          await transformPost({
             ...postFixture,
             html: new VFile(postFixture.html),
           })

--- a/src/utils/api/blog/index.ts
+++ b/src/utils/api/blog/index.ts
@@ -49,7 +49,7 @@ export const fetchPost = async (slug: string): Promise<Post> => {
     .use(rehypeMinify)
     .process(content)
 
-  return transformPost({ data, html, slug })
+  return await transformPost({ data, html, slug })
 }
 
 export const fetchPosts = async (): Promise<Array<PostPreview>> => {

--- a/src/utils/api/blog/mutators.ts
+++ b/src/utils/api/blog/mutators.ts
@@ -1,4 +1,5 @@
 import { format, formatDistanceToNow } from 'date-fns'
+import { getPlaiceholder } from 'plaiceholder'
 import readingTime from 'reading-time'
 import type { VFile } from 'vfile'
 
@@ -30,33 +31,39 @@ type Payload = {
   slug: string
 }
 
-export const transformPost = (payload: Payload): Post => ({
-  dateModified: payload.data.dateModified,
-  datePublished: {
-    formatInWords: formatDistanceToNow(
-      new Date(payload.data.datePublished + ' GMT+2'),
-      { addSuffix: true }
-    ),
-    formatDate: format(new Date(payload.data.datePublished), 'dd MMMM y'),
-    formatMonthDay: format(new Date(payload.data.datePublished), 'MMM dd'),
-    value: payload.data.datePublished,
-  },
-  disqusIdentifier: payload.data.disqusIdentifier,
-  excerpt: payload.data.excerpt,
-  html: payload.html.toString(),
-  images: {
-    featured: {
-      src: payload.data.image,
-    },
-    preview: {
-      src: payload.data.image.replace('/upload/', '/upload/w_500/'),
-      lqpi: payload.data.image.replace(
-        '/upload/',
-        '/upload/t_post-preview-lqpi/'
+export const transformPost = async (payload: Payload): Promise<Post> => {
+  const { base64 } = await getPlaiceholder(
+    payload.data.image.replace(
+      '/upload/',
+      '/upload/t_post-preview-lqpi-background-color/'
+    )
+  )
+
+  return {
+    dateModified: payload.data.dateModified,
+    datePublished: {
+      formatInWords: formatDistanceToNow(
+        new Date(payload.data.datePublished + ' GMT+2'),
+        { addSuffix: true }
       ),
+      formatDate: format(new Date(payload.data.datePublished), 'dd MMMM y'),
+      formatMonthDay: format(new Date(payload.data.datePublished), 'MMM dd'),
+      value: payload.data.datePublished,
     },
-  },
-  readingTime: readingTime(payload.html.toString()).text,
-  slug: payload.slug,
-  title: payload.data.title,
-})
+    disqusIdentifier: payload.data.disqusIdentifier,
+    excerpt: payload.data.excerpt,
+    html: payload.html.toString(),
+    images: {
+      featured: {
+        src: payload.data.image,
+      },
+      preview: {
+        src: payload.data.image.replace('/upload/', '/upload/w_500/'),
+        lqpi: base64,
+      },
+    },
+    readingTime: readingTime(payload.html.toString()).text,
+    slug: payload.slug,
+    title: payload.data.title,
+  }
+}

--- a/src/utils/theme/theme.css
+++ b/src/utils/theme/theme.css
@@ -12,15 +12,6 @@ html {
   padding: 0;
 }
 
-.lazy-blur {
-  transition: all 200ms ease-in-out;
-  filter: blur(1px);
-}
-
-.lazyloaded {
-  filter: blur(0);
-}
-
 .language-project-javascript {
   background-color: #fbdd51;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1943,6 +1943,11 @@
     tiny-glob "^0.2.9"
     tslib "^2.4.0"
 
+"@plaiceholder/next@2.5.0":
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/@plaiceholder/next/-/next-2.5.0.tgz#b232315e96a27afd47bb88b5256a3dcd45c983a0"
+  integrity sha512-vT8YtPpgQEKFtz0QiiCnH3NfyVlldYpnxR6X2sqCJvHk+pi/Be1nb62CdYQ7RoNePPcjBQoRDSPpZpGmg8mEdw==
+
 "@puppeteer/browsers@0.4.1":
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/@puppeteer/browsers/-/browsers-0.4.1.tgz#fae81939adb743420cc2466f3aa37481f7081712"
@@ -3014,6 +3019,11 @@ bl@^4.0.3, bl@^4.1.0:
     inherits "^2.0.4"
     readable-stream "^3.4.0"
 
+blurhash@1.1.5:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/blurhash/-/blurhash-1.1.5.tgz#3034104cd5dce5a3e5caa871ae2f0f1f2d0ab566"
+  integrity sha512-a+LO3A2DfxTaTztsmkbLYmUzUeApi0LZuKalwbNmqAHR6HhJGMt1qSV/R3wc+w4DL28holjqO3Bg74aUGavGjg==
+
 body-parser@1.19.0:
   version "1.19.0"
   resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.19.0.tgz#96b2709e57c9c4e09a6fd66a8fd979844f69f08a"
@@ -3418,6 +3428,11 @@ cliui@^8.0.1:
     string-width "^4.2.0"
     strip-ansi "^6.0.1"
     wrap-ansi "^7.0.0"
+
+clone@2.x:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/clone/-/clone-2.1.2.tgz#1b7f4b9f591f1e8f83670401600345a02887435f"
+  integrity sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==
 
 clone@^1.0.2:
   version "1.0.4"
@@ -3994,6 +4009,13 @@ encodeurl@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"
   integrity sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=
+
+encoding@0.1.13:
+  version "0.1.13"
+  resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.13.tgz#56574afdd791f54a8e9b2785c0582a2d26210fa9"
+  integrity sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==
+  dependencies:
+    iconv-lite "^0.6.2"
 
 end-of-stream@^1.1.0, end-of-stream@^1.4.1:
   version "1.4.4"
@@ -5341,7 +5363,7 @@ iconv-lite@0.4.24, iconv-lite@^0.4.24:
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
-iconv-lite@0.6.3:
+iconv-lite@0.6.3, iconv-lite@^0.6.2:
   version "0.6.3"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.6.3.tgz#a52f80bf38da1952eb5c681790719871a1a72501"
   integrity sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==
@@ -5369,6 +5391,13 @@ ignore@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.0.tgz#6d3bac8fa7fe0d45d9f9be7bac2fc279577e345a"
   integrity sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==
+
+image-size@1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/image-size/-/image-size-1.0.2.tgz#d778b6d0ab75b2737c1556dd631652eb963bc486"
+  integrity sha512-xfOoWjceHntRb3qFCrh5ZFORYH8XCdYpASltMhZ/Q0KZiOwjdE/Yl2QCiWdwD+lygV5bMCvauzgu5PxBX/Yerg==
+  dependencies:
+    queue "6.0.2"
 
 image-ssim@^0.2.0:
   version "0.2.0"
@@ -5412,7 +5441,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@2.0.4, inherits@^2.0.3, inherits@^2.0.4:
+inherits@2, inherits@2.0.4, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.3:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -7400,6 +7429,13 @@ node-addon-api@^6.1.0:
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-6.1.0.tgz#ac8470034e58e67d0c6f1204a18ae6995d9c0d76"
   integrity sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA==
 
+node-cache@5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/node-cache/-/node-cache-5.1.2.tgz#f264dc2ccad0a780e76253a694e9fd0ed19c398d"
+  integrity sha512-t1QzWwnk4sjLWaQAS8CHgOJ+RAfmHpxFWmc36IWTiWHQfs0w5JDMBS1b1ZxQteo0vVVuWJvIUKHDkkeK7vIGCg==
+  dependencies:
+    clone "2.x"
+
 node-fetch@2.6.7, node-fetch@^2.6.1:
   version "2.6.7"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
@@ -7910,6 +7946,17 @@ pkg-dir@^4.1.0, pkg-dir@^4.2.0:
   dependencies:
     find-up "^4.0.0"
 
+plaiceholder@2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/plaiceholder/-/plaiceholder-2.5.0.tgz#2a90c2756a597d548c8c7fae863f600de3eb0e0b"
+  integrity sha512-rygdNSWuYzs1GxxGjq2FiJdJB1AUaKhUHP/M7PIrSjAAGuoJC5ACiJx+cZZ+hDmMalxsxOMw0Sbbx3LF8jemGg==
+  dependencies:
+    blurhash "1.1.5"
+    encoding "0.1.13"
+    image-size "1.0.2"
+    node-cache "5.1.2"
+    node-fetch "2.6.7"
+
 postcss-import@^15.1.0:
   version "15.1.0"
   resolved "https://registry.yarnpkg.com/postcss-import/-/postcss-import-15.1.0.tgz#41c64ed8cc0e23735a9698b3249ffdbf704adc70"
@@ -8245,6 +8292,13 @@ qs@6.7.0:
   version "6.7.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.7.0.tgz#41dc1a015e3d581f1621776be31afb2876a9b1bc"
   integrity sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==
+
+queue@6.0.2:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/queue/-/queue-6.0.2.tgz#b91525283e2315c7553d2efa18d83e76432fed65"
+  integrity sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==
+  dependencies:
+    inherits "~2.0.3"
 
 randombytes@^2.1.0:
   version "2.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6488,11 +6488,6 @@ language-tags@^1.0.5:
   dependencies:
     language-subtag-registry "~0.3.2"
 
-lazysizes@^5.3.2:
-  version "5.3.2"
-  resolved "https://registry.yarnpkg.com/lazysizes/-/lazysizes-5.3.2.tgz#27f974c26f5fcc33e7db765c0f4930488c8a2984"
-  integrity sha512-22UzWP+Vedi/sMeOr8O7FWimRVtiNJV2HCa+V8+peZOw6QbswN9k58VUhd7i6iK5bw5QkYrF01LJbeJe0PV8jg==
-
 leven@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/leven/-/leven-3.1.0.tgz#77891de834064cccba82ae7842bb6b14a13ed7f2"


### PR DESCRIPTION
## Description

Hey! 👋🏼 

This PR replaces lazySizes with `plaiceholder`. Also it changes the way LQPI images are generated, right now we're using a Cloudinary transformation that creates a blurred LQPI version of the real image.

This approach works good, however when we convert this to `base64` to use this with `next/image` the blur makes the LQPI look weird, therefore I'm changing the Cloudinary transformation to generate an image with the predominant background color to generate the placeholder.

### Before

<img src="https://github.com/carloscuesta/carloscuesta.me/assets/7629661/b82ab87d-4d1a-4581-b5e5-2b009c0f050a" width="300"/>

### After

<img src="https://github.com/carloscuesta/carloscuesta.me/assets/7629661/c3f84678-ca46-46af-8fa3-c2fb14715b65" width="300"/>


### Impact

This change will also bring better performance to the website since we don't need to rely on external libraries that change the DOM for lazy loading, we offload this to `next/image`.

Also we will avoid requesting those images as they'll be converted to `base64` in a super tiny size given it's only a bg-color image.

## Demo

<img width="1018" alt="CleanShot 2023-05-09 at 20 09 33@2x" src="https://github.com/carloscuesta/carloscuesta.me/assets/7629661/0e760868-9f5d-4053-b676-16b31425b0d8">

<img width="1018" alt="CleanShot 2023-05-09 at 20 09 07@2x" src="https://github.com/carloscuesta/carloscuesta.me/assets/7629661/1774d247-1b27-4f55-9be0-2e478e4f97a7">


