### PR TITLE
✨ Render `/blog` as a static page

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
   "devDependencies": {
     "@lhci/cli": "^0.12.0",
     "@tailwindcss/typography": "0.5.9",
+    "@testing-library/react": "14.0.0",
     "@types/body-scroll-lock": "3.1.0",
     "@types/jest": "29.5.5",
     "@types/lodash.debounce": "4.0.7",

--- a/src/app/blog/[slug]/components/Header/ViewsCount/index.tsx
+++ b/src/app/blog/[slug]/components/Header/ViewsCount/index.tsx
@@ -1,0 +1,46 @@
+'use client'
+
+import { useEffect } from 'react'
+import useSWR from 'swr'
+
+type Props = { slug: string; views?: string }
+
+async function fetcher<JSON>(
+  input: RequestInfo,
+  init?: RequestInit,
+): Promise<JSON> {
+  const response = await fetch(input, init)
+
+  return response.json()
+}
+
+const ViewsCount = ({ slug, views }: Props) => {
+  const { data, mutate } = useSWR<{ views: Record<string, string> }>(
+    '/api/views',
+    fetcher,
+    views
+      ? {
+          fallbackData: { views: { [slug]: views } },
+        }
+      : undefined,
+  )
+
+  useEffect(() => {
+    if (slug) {
+      fetch(`/api/views/${slug}`, { method: 'POST' })
+        .then((response) => response.json())
+        .then((payload: Record<string, string>) => {
+          mutate({
+            views: {
+              ...data?.views,
+              ...payload,
+            },
+          })
+        })
+    }
+  }, [slug])
+
+  return <>{data?.views?.[slug]}</>
+}
+
+export default ViewsCount

--- a/src/app/blog/[slug]/components/Header/ViewsCount/index.tsx
+++ b/src/app/blog/[slug]/components/Header/ViewsCount/index.tsx
@@ -1,29 +1,13 @@
 'use client'
 
 import { useEffect } from 'react'
-import useSWR from 'swr'
 
-type Props = { slug: string; views?: string }
+import useViewsCount from 'src/utils/hooks/useViewsCount'
 
-async function fetcher<JSON>(
-  input: RequestInfo,
-  init?: RequestInit,
-): Promise<JSON> {
-  const response = await fetch(input, init)
+type Props = { slug: string }
 
-  return response.json()
-}
-
-const ViewsCount = ({ slug, views }: Props) => {
-  const { data, mutate } = useSWR<{ views: Record<string, string> }>(
-    '/api/views',
-    fetcher,
-    views
-      ? {
-          fallbackData: { views: { [slug]: views } },
-        }
-      : undefined,
-  )
+const ViewsCount = ({ slug }: Props) => {
+  const { data, mutate } = useViewsCount(slug)
 
   useEffect(() => {
     if (slug) {

--- a/src/app/blog/[slug]/components/Header/index.tsx
+++ b/src/app/blog/[slug]/components/Header/index.tsx
@@ -1,4 +1,4 @@
-import ViewsCount from 'src/components/ViewsCount'
+import ViewsCount from './ViewsCount'
 
 type Props = {
   datePublished: { formatInWords: string; formatDate: string; value: string }
@@ -20,7 +20,7 @@ const Header = (props: Props) => (
     </span>
 
     <span className='text-sm opacity-70 before:px-1 before:content-["•"]'>
-      <ViewsCount slug={props.slug} trackView />
+      <ViewsCount slug={props.slug} />
     </span>
   </header>
 )

--- a/src/app/blog/components/Post/ViewsCount/index.tsx
+++ b/src/app/blog/components/Post/ViewsCount/index.tsx
@@ -1,28 +1,11 @@
 'use client'
 
-import useSWR from 'swr'
+import useViewsCount from 'src/utils/hooks/useViewsCount'
 
 type Props = { slug: string; views?: string }
 
-async function fetcher<JSON>(
-  input: RequestInfo,
-  init?: RequestInit,
-): Promise<JSON> {
-  const response = await fetch(input, init)
-
-  return response.json()
-}
-
 const ViewsCount = ({ slug, views }: Props) => {
-  const { data } = useSWR<{ views: Record<string, string> }>(
-    '/api/views',
-    fetcher,
-    views
-      ? {
-          fallbackData: { views: { [slug]: views } },
-        }
-      : undefined,
-  )
+  const { data } = useViewsCount(slug, views)
 
   return <>{data?.views?.[slug]}</>
 }

--- a/src/app/blog/components/Post/ViewsCount/index.tsx
+++ b/src/app/blog/components/Post/ViewsCount/index.tsx
@@ -1,0 +1,30 @@
+'use client'
+
+import useSWR from 'swr'
+
+type Props = { slug: string; views?: string }
+
+async function fetcher<JSON>(
+  input: RequestInfo,
+  init?: RequestInit,
+): Promise<JSON> {
+  const response = await fetch(input, init)
+
+  return response.json()
+}
+
+const ViewsCount = ({ slug, views }: Props) => {
+  const { data } = useSWR<{ views: Record<string, string> }>(
+    '/api/views',
+    fetcher,
+    views
+      ? {
+          fallbackData: { views: { [slug]: views } },
+        }
+      : undefined,
+  )
+
+  return <>{data?.views?.[slug]}</>
+}
+
+export default ViewsCount

--- a/src/app/blog/components/Post/index.tsx
+++ b/src/app/blog/components/Post/index.tsx
@@ -2,7 +2,7 @@ import { Suspense } from 'react'
 import Link from 'next/link'
 
 import { type PostPreview } from 'src/utils/api/blog/mutators'
-import ViewsCount from 'src/components/ViewsCount'
+import ViewsCount from './ViewsCount'
 
 const Post = ({ post, views }: { post: PostPreview; views: string }) => (
   <li

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -8,8 +8,6 @@ import PageTitle from 'src/components/PageTitle'
 import Year from './components/Year'
 import Post from './components/Post'
 
-export const revalidate = 60
-
 export const dynamic = 'force-static'
 
 const getData = async () => {

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -8,7 +8,7 @@ import PageTitle from 'src/components/PageTitle'
 import Year from './components/Year'
 import Post from './components/Post'
 
-export const dynamic = 'force-static'
+export const dynamic = 'error'
 
 const getData = async () => {
   const posts = await fetchPosts()

--- a/src/utils/hooks/useViewsCount/__tests__/index.spec.tsx
+++ b/src/utils/hooks/useViewsCount/__tests__/index.spec.tsx
@@ -1,0 +1,17 @@
+import { renderHook } from '@testing-library/react'
+
+import * as stubs from './stubs'
+import useViewsCount from '..'
+
+describe('useViewsCount', () => {
+  it('should return data and mutate', () => {
+    const { result } = renderHook(() =>
+      useViewsCount(stubs.post.slug, stubs.post.views),
+    )
+
+    expect(result.current.data).toEqual({
+      views: { [stubs.post.slug]: stubs.post.views },
+    })
+    expect(result.current.mutate).toBeInstanceOf(Function)
+  })
+})

--- a/src/utils/hooks/useViewsCount/__tests__/stubs.ts
+++ b/src/utils/hooks/useViewsCount/__tests__/stubs.ts
@@ -1,0 +1,4 @@
+export const post = {
+  slug: 'hello-world',
+  views: '1000',
+}

--- a/src/utils/hooks/useViewsCount/index.tsx
+++ b/src/utils/hooks/useViewsCount/index.tsx
@@ -1,0 +1,26 @@
+import useSWR from 'swr'
+
+async function fetcher<JSON>(
+  input: RequestInfo,
+  init?: RequestInit,
+): Promise<JSON> {
+  const response = await fetch(input, init)
+
+  return response.json()
+}
+
+const useViewsCount = (slug: string, views?: string) => {
+  const { data, mutate } = useSWR<{ views: Record<string, string> }>(
+    '/api/views',
+    fetcher,
+    views
+      ? {
+          fallbackData: { views: { [slug]: views } },
+        }
+      : undefined,
+  )
+
+  return { data, mutate }
+}
+
+export default useViewsCount

--- a/yarn.lock
+++ b/yarn.lock
@@ -1240,6 +1240,13 @@
   dependencies:
     regenerator-runtime "^0.13.11"
 
+"@babel/runtime@^7.12.5":
+  version "7.23.1"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.23.1.tgz#72741dc4d413338a91dcb044a86f3c0bc402646d"
+  integrity sha512-hC2v6p8ZSI/W0HUzh3V8C5g+NwSKzKPtJwSpTjwl0o297GP9+ZLQSkdvHz46CM3LqyoXxq+5G9komY+eSqSO0g==
+  dependencies:
+    regenerator-runtime "^0.14.0"
+
 "@babel/template@^7.10.4":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.10.4.tgz#3251996c4200ebc71d1a8fc405fba940f36ba278"
@@ -2084,6 +2091,29 @@
     lodash.merge "^4.6.2"
     postcss-selector-parser "6.0.10"
 
+"@testing-library/dom@^9.0.0":
+  version "9.3.3"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-9.3.3.tgz#108c23a5b0ef51121c26ae92eb3179416b0434f5"
+  integrity sha512-fB0R+fa3AUqbLHWyxXa2kGVtf1Fe1ZZFr0Zp6AIbIAzXb2mKbEXl+PCQNUOaq5lbTab5tfctfXRNsWXxa2f7Aw==
+  dependencies:
+    "@babel/code-frame" "^7.10.4"
+    "@babel/runtime" "^7.12.5"
+    "@types/aria-query" "^5.0.1"
+    aria-query "5.1.3"
+    chalk "^4.1.0"
+    dom-accessibility-api "^0.5.9"
+    lz-string "^1.5.0"
+    pretty-format "^27.0.2"
+
+"@testing-library/react@14.0.0":
+  version "14.0.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-14.0.0.tgz#59030392a6792450b9ab8e67aea5f3cc18d6347c"
+  integrity sha512-S04gSNJbYE30TlIMLTzv6QCTzt9AqIF5y6s6SzVFILNcNvbV/jU96GeiTPillGQo+Ny64M/5PV7klNYYgv5Dfg==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    "@testing-library/dom" "^9.0.0"
+    "@types/react-dom" "^18.0.0"
+
 "@tootallnate/once@1":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
@@ -2093,6 +2123,11 @@
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-2.0.0.tgz#f544a148d3ab35801c1f633a7441fd87c2e484bf"
   integrity sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==
+
+"@types/aria-query@^5.0.1":
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/@types/aria-query/-/aria-query-5.0.2.tgz#6f1225829d89794fd9f891989c9ce667422d7f64"
+  integrity sha512-PHKZuMN+K5qgKIWhBodXzQslTo5P+K/6LqeKXS6O/4liIDdZqaX5RXrCK++LAw+y/nptN48YmUMFiQHRSWYwtQ==
 
 "@types/babel__core@^7.1.14":
   version "7.1.14"
@@ -2301,6 +2336,13 @@
   version "15.7.5"
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.5.tgz#5f19d2b85a98e9558036f6a3cacc8819420f05cf"
   integrity sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==
+
+"@types/react-dom@^18.0.0":
+  version "18.2.11"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.2.11.tgz#4332c315544698a0875dfdb6e320dda59e1b3d58"
+  integrity sha512-zq6Dy0EiCuF9pWFW6I6k6W2LdpUixLE4P6XjXU1QHLfak3GPACQfLwEuHzY5pOYa4hzj1d0GxX/P141aFjZsyg==
+  dependencies:
+    "@types/react" "*"
 
 "@types/react-test-renderer@18.0.1":
   version "18.0.1"
@@ -2770,6 +2812,13 @@ argv@0.0.2:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/argv/-/argv-0.0.2.tgz#ecbd16f8949b157183711b1bda334f37840185ab"
   integrity sha1-7L0W+JSbFXGDcRsb2jNPN4QBhas=
+
+aria-query@5.1.3:
+  version "5.1.3"
+  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-5.1.3.tgz#19db27cd101152773631396f7a95a3b58c22c35e"
+  integrity sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==
+  dependencies:
+    deep-equal "^2.0.5"
 
 aria-query@^4.2.2:
   version "4.2.2"
@@ -3823,6 +3872,30 @@ dedent@^1.0.0:
   resolved "https://registry.yarnpkg.com/dedent/-/dedent-1.5.0.tgz#6e0fb8016002deba2d56927ebd7e3caf7e84e22a"
   integrity sha512-3sSQTYoWKGcRHmHl6Y6opLpRJH55bxeGQ0Y1LCI5pZzUXvokVkj0FC4bi7uEwazxA9FQZ0Nv067Zt5kSUvXxEA==
 
+deep-equal@^2.0.5:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-2.2.2.tgz#9b2635da569a13ba8e1cc159c2f744071b115daa"
+  integrity sha512-xjVyBf0w5vH0I42jdAZzOKVldmPgSulmiyPRywoyq7HXC9qdgo17kxJE+rdnif5Tz6+pIrpJI8dCpMNLIGkUiA==
+  dependencies:
+    array-buffer-byte-length "^1.0.0"
+    call-bind "^1.0.2"
+    es-get-iterator "^1.1.3"
+    get-intrinsic "^1.2.1"
+    is-arguments "^1.1.1"
+    is-array-buffer "^3.0.2"
+    is-date-object "^1.0.5"
+    is-regex "^1.1.4"
+    is-shared-array-buffer "^1.0.2"
+    isarray "^2.0.5"
+    object-is "^1.1.5"
+    object-keys "^1.1.1"
+    object.assign "^4.1.4"
+    regexp.prototype.flags "^1.5.0"
+    side-channel "^1.0.4"
+    which-boxed-primitive "^1.0.2"
+    which-collection "^1.0.1"
+    which-typed-array "^1.1.9"
+
 deep-extend@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
@@ -3989,6 +4062,11 @@ doctrine@^3.0.0:
   integrity sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==
   dependencies:
     esutils "^2.0.2"
+
+dom-accessibility-api@^0.5.9:
+  version "0.5.16"
+  resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz#5a7429e6066eb3664d911e33fb0e45de8eb08453"
+  integrity sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==
 
 domexception@^4.0.0:
   version "4.0.0"
@@ -4226,6 +4304,21 @@ es-abstract@^1.21.2, es-abstract@^1.21.3:
     typed-array-length "^1.0.4"
     unbox-primitive "^1.0.2"
     which-typed-array "^1.1.10"
+
+es-get-iterator@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/es-get-iterator/-/es-get-iterator-1.1.3.tgz#3ef87523c5d464d41084b2c3c9c214f1199763d6"
+  integrity sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==
+  dependencies:
+    call-bind "^1.0.2"
+    get-intrinsic "^1.1.3"
+    has-symbols "^1.0.3"
+    is-arguments "^1.1.1"
+    is-map "^2.0.2"
+    is-set "^2.0.2"
+    is-string "^1.0.7"
+    isarray "^2.0.5"
+    stop-iteration-iterator "^1.0.0"
 
 es-iterator-helpers@^1.0.12:
   version "1.0.13"
@@ -5735,7 +5828,7 @@ internal-slot@^1.0.3:
     has "^1.0.3"
     side-channel "^1.0.4"
 
-internal-slot@^1.0.5:
+internal-slot@^1.0.4, internal-slot@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/internal-slot/-/internal-slot-1.0.5.tgz#f2a2ee21f668f8627a4667f309dc0f4fb6674986"
   integrity sha512-Y+R5hJrzs52QCG2laLn4udYVnxsfny9CpOhNhUvk/SSSVyF6T27FzRbF0sroPidSu3X8oEAkOn2K804mjpt6UQ==
@@ -5779,7 +5872,7 @@ is-alphanumerical@^2.0.0:
     is-alphabetical "^2.0.0"
     is-decimal "^2.0.0"
 
-is-arguments@^1.0.4:
+is-arguments@^1.0.4, is-arguments@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/is-arguments/-/is-arguments-1.1.1.tgz#15b3f88fda01f2a97fec84ca761a560f123efa9b"
   integrity sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==
@@ -5944,7 +6037,7 @@ is-interactive@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-interactive/-/is-interactive-1.0.0.tgz#cea6e6ae5c870a7b0a0004070b7b587e0252912e"
   integrity sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==
 
-is-map@^2.0.1:
+is-map@^2.0.1, is-map@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/is-map/-/is-map-2.0.2.tgz#00922db8c9bf73e81b7a335827bc2a43f2b91127"
   integrity sha512-cOZFQQozTha1f4MxLFzlgKYPTyj26picdZTx82hbc/Xf4K/tZOOXSCkMvU4pKioRXGDLJRn0GM7Upe7kR721yg==
@@ -6035,7 +6128,7 @@ is-regexp@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-regexp/-/is-regexp-1.0.0.tgz#fd2d883545c46bac5a633e7b9a09e87fa2cb5069"
   integrity sha1-/S2INUXEa6xaYz57mgnof6LLUGk=
 
-is-set@^2.0.1:
+is-set@^2.0.1, is-set@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/is-set/-/is-set-2.0.2.tgz#90755fa4c2562dc1c5d4024760d6119b94ca18ec"
   integrity sha512-+2cnTEZeY5z/iXGbLhPrOAaK/Mau5k5eXq9j14CpRTftq0pAJu2MwVRSZhyZWBzx3o6X795Lz6Bpb6R0GKf37g==
@@ -7037,6 +7130,11 @@ lru_map@^0.3.3:
   resolved "https://registry.yarnpkg.com/lru_map/-/lru_map-0.3.3.tgz#b5c8351b9464cbd750335a79650a0ec0e56118dd"
   integrity sha512-Pn9cox5CsMYngeDbmChANltQl+5pi6XmTrraMSzhPmMBbmgcxmqWry0U3PGapCU1yB4/LqCcom7qhHZiF/jGfQ==
 
+lz-string@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/lz-string/-/lz-string-1.5.0.tgz#c1ab50f77887b712621201ba9fd4e3a6ed099941"
+  integrity sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==
+
 magic-string@^0.25.0, magic-string@^0.25.7:
   version "0.25.7"
   resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.25.7.tgz#3f497d6fd34c669c6798dcb821f2ef31f5445051"
@@ -7856,6 +7954,14 @@ object-inspect@^1.11.0, object-inspect@^1.12.0, object-inspect@^1.12.2, object-i
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.12.3.tgz#ba62dffd67ee256c8c086dfae69e016cd1f198b9"
   integrity sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==
 
+object-is@^1.1.5:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/object-is/-/object-is-1.1.5.tgz#b9deeaa5fc7f1846a0faecdceec138e5778f53ac"
+  integrity sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.3"
+
 object-keys@^1.0.11, object-keys@^1.0.12, object-keys@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
@@ -8392,6 +8498,15 @@ pretty-bytes@^5.3.0, pretty-bytes@^5.4.1:
   resolved "https://registry.yarnpkg.com/pretty-bytes/-/pretty-bytes-5.4.1.tgz#cd89f79bbcef21e3d21eb0da68ffe93f803e884b"
   integrity sha512-s1Iam6Gwz3JI5Hweaz4GoCD1WUNUIyzePFy5+Js2hjwGVt2Z79wNN+ZKOZ2vB6C+Xs6njyB84Z1IthQg8d9LxA==
 
+pretty-format@^27.0.2:
+  version "27.5.1"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-27.5.1.tgz#2181879fdea51a7a5851fb39d920faa63f01d88e"
+  integrity sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==
+  dependencies:
+    ansi-regex "^5.0.1"
+    ansi-styles "^5.0.0"
+    react-is "^17.0.1"
+
 pretty-format@^29.0.0, pretty-format@^29.7.0:
   version "29.7.0"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-29.7.0.tgz#ca42c758310f365bfa71a0bda0a807160b776812"
@@ -8583,6 +8698,11 @@ react-is@^16.13.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
+react-is@^17.0.1:
+  version "17.0.2"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
+  integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
+
 react-shallow-renderer@^16.15.0:
   version "16.15.0"
   resolved "https://registry.yarnpkg.com/react-shallow-renderer/-/react-shallow-renderer-16.15.0.tgz#48fb2cf9b23d23cde96708fe5273a7d3446f4457"
@@ -8678,6 +8798,11 @@ regenerator-runtime@^0.13.4:
   version "0.13.5"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz#d878a1d094b4306d10b9096484b33ebd55e26697"
   integrity sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA==
+
+regenerator-runtime@^0.14.0:
+  version "0.14.0"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz#5e19d68eb12d486f797e15a3c6a918f7cec5eb45"
+  integrity sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA==
 
 regenerator-transform@^0.14.2:
   version "0.14.4"
@@ -9610,6 +9735,13 @@ stack-utils@^2.0.3:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
   integrity sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=
+
+stop-iteration-iterator@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/stop-iteration-iterator/-/stop-iteration-iterator-1.0.0.tgz#6a60be0b4ee757d1ed5254858ec66b10c49285e4"
+  integrity sha512-iCGQj+0l0HOdZ2AEeBADlsRC+vsnDsZsbdSiH1yNSjcfKM7fdpCMfqAL/dwF5BLiw/XhRft/Wax6zQbhq2BcjQ==
+  dependencies:
+    internal-slot "^1.0.4"
 
 stream-events@^1.0.5:
   version "1.0.5"


### PR DESCRIPTION
## Description

Hey! 👋🏼 

Noticed lately that in one random deployment, Next.js changed the way a specific page was rendered (with no change on the code whatsoever) and no relevant dependency updates in between:

> ![CleanShot 2023-10-08 at 20 25 22@2x](https://github.com/carloscuesta/carloscuesta.me/assets/7629661/6b70325a-e503-4718-b248-331f91a0e20f)

> ![CleanShot 2023-10-08 at 20 25 32@2x](https://github.com/carloscuesta/carloscuesta.me/assets/7629661/ac293112-caa0-4772-99d6-77b45045ada1)


After a few hours debugging the issue I was able to narrow this down to a specific fetch `POST` request that was happening inside the `ViewsCount` component.

This request was not happening on one use-case `blog` but still Next was unable to identify this and was setting this page as `dynamic` instead of `static` which lead to performance issues and even rendering errors (since posts are statically compiled using the filesystem).
