### PR TITLE
🐛 Add `frame-src` to `Content-Security-Policy`

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -15,6 +15,7 @@ const cspHeader = `
     base-uri 'self';
     form-action 'self';
     frame-ancestors 'none';
+    frame-src https://codesandbox.io https://youtube.com;
     ${process.env.NODE_ENV === 'development' ? '' : 'upgrade-insecure-requests'};
 `
 


### PR DESCRIPTION
## Description

Hey! 👋🏼 

Adding `frame-src` to the `Content-Security-Policy` to allow loading iframes from `codesandbox` and `youtube` for the blog posts.
