### PR TITLE
✨ Support `light` & `dark` only images in blog posts

### DIFF
--- a/src/mdx-components.tsx
+++ b/src/mdx-components.tsx
@@ -1,15 +1,25 @@
 import { MDXComponents } from 'mdx/types'
 import Image, { ImageProps } from 'next/image'
 import Playground from './app/blog/[slug]/components/Playground'
+import cn from 'src/utils/cn'
 
 const components = {
-  img: (props) => (
-    <Image
-      sizes="100vw"
-      style={{ width: '100%', height: 'auto' }}
-      {...(props as ImageProps)}
-    />
-  ),
+  img: (props) => {
+    const isDarkModeOnly = props.src.includes('#dark-mode-only')
+    const isLightModeOnly = props.src.includes('#light-mode-only')
+
+    return (
+      <Image
+        sizes="100vw"
+        style={{ width: '100%', height: 'auto' }}
+        className={cn(
+          isDarkModeOnly && 'hidden dark:block',
+          isLightModeOnly && 'block dark:hidden',
+        )}
+        {...(props as ImageProps)}
+      />
+    )
+  },
   Playground,
 } satisfies MDXComponents
 


### PR DESCRIPTION
## Description

Hey! 👋🏼 

This PR adds support for using `light` & `dark` only images in Markdown posts. Like this:

```mdx
![alt](https://res.cloudinary.com/carloscuesta/image/upload/v1746169949/test.png#light-mode-only)
![alt](https://res.cloudinary.com/carloscuesta/image/upload/v1746169949/test.png#dark-mode-only)
```

## Demo

<!-- Please insert a preview of your changes here, screenshot/video/preview -->
